### PR TITLE
use prebuilt gnureadline for python dockerfile

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ pygments
 pyzmq
 jsonschema
 rabbitpy
-readline
+gnureadline
 requests
 stomp.py
 statelessd


### PR DESCRIPTION
building and installing `readline` python module from source was problematic for me (could not run Docker compose successfully)

using prebuilt `gnureadline` made `docker-compose` built successful

moreover, latest `readline` module (6.4.2) [release notes](https://pypi.org/project/readline/) marks it as deprecated and suggest to use `gnureadline`

## hardware
macbook air M1

